### PR TITLE
fix: Workflow Improvements and Uninstallation Enhancements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Go cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Fix tag
         run: |
           git config --global user.name 'GitHub Actions'
@@ -34,6 +44,15 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '1.21'
+          cache: true
+
+      - name: Cache Build
+        uses: actions/cache@v3
+        with:
+          path: tmp
+          key: ${{ runner.os }}-build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-build-
 
       - name: Build and Test
         shell: bash

--- a/internal/commands/uninstall.go
+++ b/internal/commands/uninstall.go
@@ -1,16 +1,36 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/AriajSarkar/ariaj/internal/utils"
 	"github.com/spf13/cobra"
 )
 
 func UninstallCmd() *cobra.Command {
-	return &cobra.Command{
+	var forceUninstall bool
+
+	cmd := &cobra.Command{
 		Use:   "uninstall",
 		Short: "Uninstall ariaj CLI",
+		Long: `Uninstall ariaj CLI completely from your system including:
+- Binary files
+- Configuration directory
+- PATH environment entries`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if !forceUninstall {
+				fmt.Print("Are you sure you want to uninstall ariaj? [y/N]: ")
+				var response string
+				fmt.Scanln(&response)
+				if response != "y" && response != "Y" {
+					fmt.Println("Uninstallation cancelled")
+					return nil
+				}
+			}
 			return utils.Uninstall()
 		},
 	}
+
+	cmd.Flags().BoolVarP(&forceUninstall, "force", "f", false, "Force uninstall without confirmation")
+	return cmd
 }

--- a/internal/utils/installer.go
+++ b/internal/utils/installer.go
@@ -13,7 +13,7 @@ func getInstallPath() (string, error) {
 	switch runtime.GOOS {
 	case "windows":
 		// First try Program Files, fallback to AppData
-		destPath := filepath.Join("C:", "Program Files", "ariaj")
+		destPath := filepath.Join("C:\\", "Program Files", "ariaj")
 		if err := os.MkdirAll(destPath, 0755); err != nil {
 			destPath = filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Local", "ariaj")
 		}
@@ -126,25 +126,5 @@ func Install() error {
 	if runtime.GOOS != "windows" {
 		fmt.Println("Please restart your terminal or source your shell configuration file")
 	}
-	return nil
-}
-
-func Uninstall() error {
-	destPath, err := getInstallPath()
-	if err != nil {
-		return err
-	}
-
-	binName := "ariaj"
-	if runtime.GOOS == "windows" {
-		binName = "ariaj.exe"
-	}
-
-	destFile := filepath.Join(destPath, binName)
-	if err := os.Remove(destFile); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove executable: %v", err)
-	}
-
-	fmt.Println("Ariaj has been uninstalled successfully")
 	return nil
 }

--- a/internal/utils/uninstall.go
+++ b/internal/utils/uninstall.go
@@ -1,0 +1,170 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func getGoPaths() []string {
+	paths := []string{}
+
+	// Check GOPATH first
+	if goPath := os.Getenv("GOPATH"); goPath != "" {
+		paths = append(paths, filepath.Join(goPath, "bin"))
+	}
+
+	// Check default Go installation paths
+	switch runtime.GOOS {
+	case "windows":
+		paths = append(paths, filepath.Join(os.Getenv("USERPROFILE"), "go", "bin"))
+	case "darwin":
+		paths = append(paths,
+			filepath.Join(os.Getenv("HOME"), "go", "bin"),
+			"/usr/local/go/bin",
+		)
+	default: // Linux and others
+		paths = append(paths,
+			filepath.Join(os.Getenv("HOME"), "go", "bin"),
+			"/usr/local/go/bin",
+		)
+	}
+	return paths
+}
+
+func cleanupWindowsPATH() error {
+	cmd := exec.Command("powershell", "-Command", `
+		$userPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::User)
+		$systemPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
+		
+		# Clean from User PATH
+		$userPath = ($userPath -split ';' | Where-Object { $_ -notmatch 'ariaj' }) -join ';'
+		[Environment]::SetEnvironmentVariable("PATH", $userPath, [EnvironmentVariableTarget]::User)
+		
+		# Clean from System PATH
+		$systemPath = ($systemPath -split ';' | Where-Object { $_ -notmatch 'ariaj' }) -join ';'
+		[Environment]::SetEnvironmentVariable("PATH", $systemPath, [EnvironmentVariableTarget]::Machine)
+	`)
+	return cmd.Run()
+}
+
+func cleanupUnixPath() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	// Common shell config files
+	configFiles := []string{
+		filepath.Join(home, ".bashrc"),
+		filepath.Join(home, ".zshrc"),
+		filepath.Join(home, ".profile"),
+		filepath.Join(home, ".bash_profile"),
+	}
+
+	for _, file := range configFiles {
+		if _, err := os.Stat(file); err == nil {
+			// Read file content
+			content, err := os.ReadFile(file)
+			if err != nil {
+				continue
+			}
+
+			// Remove ariaj-related PATH entries
+			lines := strings.Split(string(content), "\n")
+			newLines := []string{}
+			for _, line := range lines {
+				if !strings.Contains(line, "ariaj") {
+					newLines = append(newLines, line)
+				}
+			}
+
+			// Write back if changed
+			if len(lines) != len(newLines) {
+				err = os.WriteFile(file, []byte(strings.Join(newLines, "\n")), 0644)
+				if err == nil {
+					fmt.Printf("Cleaned PATH from %s\n", file)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func Uninstall() error {
+	fmt.Println("Starting Ariaj uninstallation...")
+
+	// Get all possible installation paths
+	possiblePaths := []string{}
+
+	switch runtime.GOOS {
+	case "windows":
+		possiblePaths = append(possiblePaths,
+			filepath.Join("C:\\", "Program Files", "ariaj"),
+			filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Local", "ariaj"),
+		)
+	case "darwin":
+		possiblePaths = append(possiblePaths,
+			"/usr/local/bin",
+			filepath.Join(os.Getenv("HOME"), ".local", "bin"),
+		)
+	default: // Linux and others
+		possiblePaths = append(possiblePaths,
+			"/usr/local/bin",
+			filepath.Join(os.Getenv("HOME"), ".local", "bin"),
+		)
+	}
+
+	// Add Go paths
+	possiblePaths = append(possiblePaths, getGoPaths()...)
+
+	// Remove binary from all possible locations
+	binName := "ariaj"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+
+	for _, path := range possiblePaths {
+		binPath := filepath.Join(path, binName)
+		if err := os.Remove(binPath); err == nil {
+			fmt.Printf("Removed binary from: %s\n", path)
+		}
+
+		// Only remove directories we created (not Go or system dirs)
+		if !strings.Contains(path, "go") && !strings.Contains(path, "bin") {
+			if err := os.Remove(path); err == nil {
+				fmt.Printf("Removed directory: %s\n", path)
+			}
+		}
+	}
+
+	// Remove config directory
+	configDir := filepath.Join(func() string {
+		if runtime.GOOS == "windows" {
+			return os.Getenv("USERPROFILE")
+		}
+		return os.Getenv("HOME")
+	}(), ".ariaj")
+
+	if err := os.RemoveAll(configDir); err == nil {
+		fmt.Printf("Removed config directory: %s\n", configDir)
+	}
+
+	// Cleanup PATH based on platform
+	if runtime.GOOS == "windows" {
+		if err := cleanupWindowsPATH(); err != nil {
+			fmt.Printf("Warning: Failed to clean Windows PATH: %v\n", err)
+		}
+	} else {
+		if err := cleanupUnixPath(); err != nil {
+			fmt.Printf("Warning: Failed to clean shell configs: %v\n", err)
+		}
+	}
+
+	fmt.Println("\nUninstallation complete!")
+	fmt.Println("Note: Please restart your terminal for changes to take effect")
+	return nil
+}


### PR DESCRIPTION
This pull request includes several changes to enhance the release workflow and improve the uninstallation process for the `ariaj` CLI. Key changes involve setting up caching in the GitHub Actions workflow and refactoring the uninstallation command to include more comprehensive cleanup.

### Workflow Improvements:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R19-R28): Added Go cache setup to speed up builds by caching Go modules and build outputs. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R19-R28) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R47-R55)

### Uninstallation Enhancements:
* [`internal/commands/uninstall.go`](diffhunk://#diff-34840d729f1ddf8a3778051dd3d70630bebc2ccb16d37c835af004c09b7a2a5aR4-R35): Updated the `uninstall` command to include a force flag and added a confirmation prompt for uninstallation.
* [`internal/utils/installer.go`](diffhunk://#diff-40eada3856c2bceed5d6a868bf6928bb0bc4c9061776737f497aa642f13e2e52L16-R16): Corrected the path separator for Windows in the `getInstallPath` function.
* [`internal/utils/uninstall.go`](diffhunk://#diff-fca5e9add6c78d4d9423d33a8a15401b9bf9fb8fbab0c2aeec120611ed076a0aR1-R170): Moved the `Uninstall` function to a new file and expanded it to remove binaries from all possible locations, clean up configuration directories, and update the system PATH.